### PR TITLE
Update camecthub.py

### DIFF
--- a/custom_components/camect/camecthub.py
+++ b/custom_components/camect/camecthub.py
@@ -217,7 +217,7 @@ class CamectHub(Entity):
             # ATTR_ENTITY_ID: cam_entity_id,
             ATTR_DEVICE_ID: cam_entity_id,
             CONF_TYPE: evt_type,
-            ATTR_RAW_DATA: str(evt),
+            ATTR_RAW_DATA: evt,
         }
         _LOGGER.info("Firing camera event to bus: %s", str(data))
         self.hass.bus.async_fire(ATTR_CAMECT_EVENT, data)


### PR DESCRIPTION
removing the string statement that seems to prevent Home Assistant being able to parse out the event data in the nested-json payload.